### PR TITLE
add 'args' tag for variadic slice arguments

### DIFF
--- a/bflags/bind.go
+++ b/bflags/bind.go
@@ -126,11 +126,20 @@ func SetArgs(c *cobra.Command, args []string) (interface{}, error) {
 				if arg == "" {
 					continue
 				}
+
 				// support for variadic args with slices arg
+				fb := argset.Flags[i]
 				if i == len(argset.Flags)-1 && len(args) > len(argset.Flags) && isSliceValue(f) {
-					arg = strings.Join(args[i:], ",")
+					if ssv, ok := f.Value.(flag.SliceValue); ok && fb.ArgsSlice {
+						err = ssv.Replace(args[i:])
+					} else {
+						// legacy behavior relying on CSV parsing
+						err = f.Value.Set(strings.Join(args[i:], ","))
+					}
+				} else {
+					err = f.Value.Set(arg)
 				}
-				err = f.Value.Set(arg)
+
 				if err != nil {
 					return nil, ex(err)
 				}

--- a/bflags/doc.go
+++ b/bflags/doc.go
@@ -5,9 +5,12 @@
 
 		Syntax
 
-		Tag are specified using 'cmd' followed by either 'flag' or 'arg':
+		Tag are specified using 'cmd' followed by either 'flag', 'arg' or 'args':
 			flag, name, usage, shorthand, persistent, required, hidden
 			arg,  name, usage, order
+		The args tag is identical to 'arg' but may be specified only for the last
+		argument of the command and is useful for slice argument (variadic arguments)
+		When used, value are set without CSV parsing.
 
 		sample:
 			flag  `cmd:"flag,id,content id,i,true,true,false"`

--- a/bflags/flags.go
+++ b/bflags/flags.go
@@ -34,6 +34,7 @@ type FlagBond struct {
 	Persistent  bool        // true: the flag is available to the command as well as every command under the command
 	Hidden      bool        // true to set the flag as hidden
 	ArgOrder    int         // for flags used to bind args
+	ArgsSlice   bool        // for flags used to bind slice args
 	CsvSlice    bool        // true for flags with comma separated string representation
 	Annotations []string    // annotations found as 'meta' tag
 }
@@ -163,6 +164,7 @@ func (f *FlagBond) MarshalJSON() ([]byte, error) {
 		Value       interface{} `json:"value,omitempty"`
 		Usage       string      `json:"usage"`
 		ArgOrder    int         `json:"arg_order"`
+		ArgSlice    bool        `json:"arg_slice,omitempty"`
 		Annotations []string    `json:"annotations"`
 	}
 	var jsn []byte
@@ -173,6 +175,7 @@ func (f *FlagBond) MarshalJSON() ([]byte, error) {
 			Value:       f.Value,
 			Usage:       f.Usage,
 			ArgOrder:    f.ArgOrder,
+			ArgSlice:    f.ArgsSlice,
 			Annotations: f.Annotations,
 		}
 		jsn, err = json.Marshal(a)


### PR DESCRIPTION
Use new tags `args` for variadic slice arguments. An error is returned if not the last argument.

```
type input struct {
	Args []string `cmd:"args,arguments,args description,0"`
}
```

<details><summary>Full example</summary>
<p>

```
type input struct {
	Args []string `cmd:"args,arguments,args description,0"`
}

func root() (*cobra.Command, error) {
	ret := bflags.NewBinder(
		&input{},
		&cobra.Command{
			Use:   "",
			Short: "trial",
			Args:  cobra.MinimumNArgs(0),
		},
		func(in *input) error {
			fmt.Println("-----")
			for i, arg := range in.Args {
				fmt.Println(i, ":", arg)
			}
			return nil
		},
		nil,
	)
	return ret.Command, ret.Error
}

func main() {
	cmdRoot, err := root()
	if err != nil {
		// initialisation error won't be reported, print it here
		fmt.Println(err)
		os.Exit(1)
	}

	err = cmdRoot.Execute()
	if err != nil {
		if !cmdRoot.SilenceUsage {
			// report the error if the command was not started yet (SilenceUsage is false).
			_, _ = fmt.Fprintln(os.Stderr, err.Error())
		}
		os.Exit(1)
	}
}
```

</p>
</details> 